### PR TITLE
Issue #2 - control server default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ and follows best practices of cache-control to easily speed up your large reques
 
 3. The cached_endpoints can be used to define all the endpoints you want to cache. 
     This gives you can central place where you can keep track of all the cached endpoints.
-4. The default cache max-age is 60 secs, to overwrite that in the API request send the following header
+4. The default cache max-age is defined via `CACHE_FASTAPI_DEFAULT_CACHE_TTL` environmental variable and defaults to 60 secs. To overwrite that in the API request send the following header
     </br>`Cache-Control: max-age=time`
     </br>Here time needs to be in seconds.
 5. Once a response is cached, you'll be able to get the cached response age in the response header `Cache-Control`

--- a/cache_fastapi/cacheMiddleware.py
+++ b/cache_fastapi/cacheMiddleware.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import os
 from fastapi import Request
 from starlette.concurrency import iterate_in_threadpool
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -7,17 +8,21 @@ from starlette.responses import StreamingResponse, Response
 
 from cache_fastapi.Backends.base_backend import BaseBackend
 
+DEFAULT_CACHE_TTL = int(os.getenv("CACHE_FASTAPI_DEFAULT_CACHE_TTL", 60))
+
 
 class CacheMiddleware(BaseHTTPMiddleware):
     def __init__(
             self,
             app,
             cached_endpoints: List[str],
-            backend: BaseBackend
+            backend: BaseBackend,
+            default_cache_ttl: int = DEFAULT_CACHE_TTL,
     ):
         super().__init__(app)
         self.cached_endpoints = cached_endpoints
         self.backend = backend
+        self.default_cache_control = f'max-age={default_cache_ttl}'
 
     def matches_any_path(self, path_url):
         for pattern in self.cached_endpoints:
@@ -28,7 +33,7 @@ class CacheMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         path_url = request.url.path
         request_type = request.method
-        cache_control = request.headers.get('Cache-Control', 'max-age=60')
+        cache_control = request.headers.get('Cache-Control', self.default_cache_control)
         auth = request.headers.get('Authorization', "token public")
         token = auth.split(" ")[1]
 


### PR DESCRIPTION
Sets default server-side cache time based on `CACHE_FASTAPI_DEFAULT_CACHE_TTL` environmental variable (or defaults to 60)